### PR TITLE
Add migration notice to documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # node-cartesi-machine
 
+> This repository has moved to [deroll](https://github.com/tuler/deroll) and is now published to the [@deroll/cm](https://www.npmjs.com/package/@deroll/cm/v/alpha) package. Please file issues and follow development there.
+
 This is a JavaScript/TypeScript library for interacting with Cartesi Machines.
 
 ## Documentation

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,5 +1,9 @@
 # Cartesi Machine + Node.js
 
+:::warning
+This repository has moved to [deroll](https://github.com/tuler/deroll) and is now published to the [@deroll/cm](https://www.npmjs.com/package/@deroll/cm/v/alpha) package. Please file issues and follow development there.
+:::
+
 The [Cartesi machine emulator](https://github.com/cartesi/machine-emulator) is distributed as a C dynamic library, and can be used from any programming language that provides some kind of C code integration. Node.js is no exception, and this library provides a binding using FFI through the [koffi](https://koffi.dev) library.
 
 It provides a fully typed and ergonomic TypeScript API for the Cartesi Machine C API and the Cartesi Machine JSON-RPC API, which allows you to create, manage, and interact with local or remote Cartesi machines from TypeScript/JavaScript applications.


### PR DESCRIPTION
## Summary
This PR adds migration notices to the project documentation and README to inform users that this repository has been moved to the [deroll](https://github.com/tuler/deroll) project and is now published under the [@deroll/cm](https://www.npmjs.com/package/@deroll/cm/v/alpha) package.

## Changes
- Added a warning admonition to the documentation homepage (`docs/pages/index.mdx`) directing users to the new repository location and package
- Added a notice to the README.md file with the same migration information

## Details
The notices inform users to:
- File issues in the new [deroll](https://github.com/tuler/deroll) repository
- Follow development in the new location
- Use the new [@deroll/cm](https://www.npmjs.com/package/@deroll/cm/v/alpha) npm package

This helps ensure users are aware of the project relocation and directs them to the correct location for ongoing support and development.

https://claude.ai/code/session_01XJB2yWomofyrRYTZGQT2B9